### PR TITLE
Add address registry to Corfucoin page

### DIFF
--- a/index.html
+++ b/index.html
@@ -351,6 +351,13 @@
 
                 <p><strong>Mining Corfucoin</strong></p>
                 <p>Corfucoin is a fork of Litecoin, which uses a scrypt proof-of-work scheme. Corfucoins can be mined by using <a href="https://github.com/pooler/cpuminer">cpuminer</a>.</p>
+                
+                <p><strong>Address registry</strong></p>
+                <p>If you would like to share your Corfucoin address with the other attendees, you may use the address registry.</p>
+                <ul>
+                    <li><a href='https://docs.google.com/forms/d/1xnuL5Ftu_U5o-tV-Ti5pICu5D1gsTqrZKV8DOldsM5w/viewform?c=0&w=1&usp=mail_form_link'>Add address to the registry</a></li>
+                    <li><a href='https://docs.google.com/spreadsheets/d/1yxmzqW1p4LUgk_MAnulAgkWqa5EWbKSAiaouGf3uW1A/pubhtml'>View the registry</a></li>
+                </ul>
             </section>
 
         </div>

--- a/index.html
+++ b/index.html
@@ -348,9 +348,6 @@
                     </li>
                     <li><a href='https://github.com/musalbas/Corfucoin'>Get the source code</a></li>
                 </ul>
-
-                <p><strong>Mining Corfucoin</strong></p>
-                <p>Corfucoin is a fork of Litecoin, which uses a scrypt proof-of-work scheme. Corfucoins can be mined by using <a href="https://github.com/pooler/cpuminer">cpuminer</a>.</p>
                 
                 <p><strong>Address registry</strong></p>
                 <p>If you would like to share your Corfucoin address with the other attendees, you may use the address registry.</p>
@@ -358,6 +355,9 @@
                     <li><a href='https://docs.google.com/forms/d/1xnuL5Ftu_U5o-tV-Ti5pICu5D1gsTqrZKV8DOldsM5w/viewform?c=0&w=1&usp=mail_form_link'>Add address to the registry</a></li>
                     <li><a href='https://docs.google.com/spreadsheets/d/1yxmzqW1p4LUgk_MAnulAgkWqa5EWbKSAiaouGf3uW1A/pubhtml'>View the registry</a></li>
                 </ul>
+
+                <p><strong>Mining Corfucoin</strong></p>
+                <p>Corfucoin is a fork of Litecoin, which uses a scrypt proof-of-work scheme. Corfucoins can be mined by using <a href="https://github.com/pooler/cpuminer">cpuminer</a>.</p>
             </section>
 
         </div>


### PR DESCRIPTION
This adds an address registry to the Corfucoin page for attendees to share their address (sorry for the undescriptive commit).
